### PR TITLE
Improve filetype handling and async execution in buffers

### DIFF
--- a/lua/nvim-chezmoi/chezmoi/commands/edit.lua
+++ b/lua/nvim-chezmoi/chezmoi/commands/edit.lua
@@ -199,7 +199,13 @@ function M:detect_filetype(buf)
       end
 
       if ft ~= nil and ft ~= "" then
-        set_filetype(ft)
+        if
+          vim.api.nvim_buf_is_valid(buf)
+          and vim.api.nvim_buf_get_name(buf) == source_file
+          and vim.bo[buf].filetype ~= ft
+        then
+          vim.bo[buf].filetype = ft
+        end
 
         vim.filetype.add({
           filename = {

--- a/lua/nvim-chezmoi/chezmoi/commands/edit.lua
+++ b/lua/nvim-chezmoi/chezmoi/commands/edit.lua
@@ -165,6 +165,7 @@ function M:detect_filetype(buf)
 
   -- Try cache first
   local cached = chezmoi_cache.find_success("ft_detect", { source_file })
+
   if cached ~= nil then
     local ft = cached.result.data.ft
     if ft ~= vim.bo[buf].filetype then
@@ -174,45 +175,47 @@ function M:detect_filetype(buf)
   end
 
   -- Get target path for source file
-  local target_file_result =
-    require("nvim-chezmoi.chezmoi.commands.target_path"):exec({ source_file })
+  require("nvim-chezmoi.chezmoi.commands.target_path"):async(
+    { source_file },
+    function(target_file_result)
+      if not target_file_result.success then
+        return
+      end
 
-  if not target_file_result.success then
-    return
-  end
+      local target_file = target_file_result.data[1]
 
-  local target_file = target_file_result.data[1]
+      -- Try match
+      local ft = plenary_filetype.detect(target_file, {})
+      if ft == nil or ft == "" then
+        ft = vim.filetype.match({ filename = target_file }) or ""
+      end
 
-  -- Try match
-  local ft = plenary_filetype.detect(target_file, {})
-  if ft == nil or ft == "" then
-    ft = vim.filetype.match({ filename = target_file }) or ""
-  end
+      -- Could't find the filetype, try temp buf
+      if ft == nil or ft == "" then
+        local tmp_buf = vim.api.nvim_create_buf(true, true)
+        vim.api.nvim_buf_set_name(tmp_buf, target_file)
+        ft = vim.filetype.match({ buf = tmp_buf }) or ""
+        vim.api.nvim_buf_delete(tmp_buf, { force = true })
+      end
 
-  -- Could't find the filetype, try temp buf
-  if ft == nil or ft == "" then
-    local tmp_buf = vim.api.nvim_create_buf(true, true)
-    vim.api.nvim_buf_set_name(tmp_buf, target_file)
-    ft = vim.filetype.match({ buf = tmp_buf }) or ""
-    vim.api.nvim_buf_delete(tmp_buf, { force = true })
-  end
+      if ft ~= nil and ft ~= "" then
+        set_filetype(ft)
 
-  if ft ~= nil and ft ~= "" then
-    set_filetype(ft)
+        vim.filetype.add({
+          filename = {
+            [vim.fn.fnamemodify(source_file, ":t")] = ft,
+          },
+        })
 
-    vim.filetype.add({
-      filename = {
-        [vim.fn.fnamemodify(source_file, ":t")] = ft,
-      },
-    })
-
-    -- Cache it
-    chezmoi_cache.new("ft_detect", { source_file }, {
-      args = {},
-      success = true,
-      data = { ft = ft },
-    })
-  end
+        -- Cache it
+        chezmoi_cache.new("ft_detect", { source_file }, {
+          args = {},
+          success = true,
+          data = { ft = ft },
+        })
+      end
+    end
+  )
 end
 
 return M

--- a/lua/nvim-chezmoi/chezmoi/commands/edit.lua
+++ b/lua/nvim-chezmoi/chezmoi/commands/edit.lua
@@ -192,10 +192,15 @@ function M:detect_filetype(buf)
 
       -- Could't find the filetype, try temp buf
       if ft == nil or ft == "" then
-        local tmp_buf = vim.api.nvim_create_buf(true, true)
-        vim.api.nvim_buf_set_name(tmp_buf, target_file)
-        ft = vim.filetype.match({ buf = tmp_buf }) or ""
-        vim.api.nvim_buf_delete(tmp_buf, { force = true })
+        local existing = vim.fn.bufnr(target_file)
+        if existing ~= -1 and vim.api.nvim_buf_is_valid(existing) then
+          ft = vim.filetype.match({ buf = existing }) or ""
+        else
+          local tmp_buf = vim.api.nvim_create_buf(true, true)
+          vim.api.nvim_buf_set_name(tmp_buf, target_file)
+          ft = vim.filetype.match({ buf = tmp_buf }) or ""
+          vim.api.nvim_buf_delete(tmp_buf, { force = true })
+        end
       end
 
       if ft ~= nil and ft ~= "" then

--- a/lua/nvim-chezmoi/init.lua
+++ b/lua/nvim-chezmoi/init.lua
@@ -55,13 +55,6 @@ local setup_plugin = function()
     group = utils.augroup("SourcePath"),
     pattern = M.opts.source_path .. "/*",
     callback = function(ev)
-      local b = ev.buf
-      local b_ftype = vim.bo[b].filetype
-
-      if not b_ftype or b_ftype == "" then
-        return
-      end
-
       chezmoi_edit:on_edit(ev.buf)
     end,
   })

--- a/lua/nvim-chezmoi/init.lua
+++ b/lua/nvim-chezmoi/init.lua
@@ -55,6 +55,13 @@ local setup_plugin = function()
     group = utils.augroup("SourcePath"),
     pattern = M.opts.source_path .. "/*",
     callback = function(ev)
+      local b = ev.buf
+      local b_ftype = vim.bo[b].filetype
+
+      if not b_ftype or b_ftype == "" then
+        return
+      end
+
       chezmoi_edit:on_edit(ev.buf)
     end,
   })


### PR DESCRIPTION
Fixes https://github.com/andre-kotake/nvim-chezmoi/issues/25

Opening a virtual buffer  (e.g. neo-tree "X hidden items") threw `chezmoi: stat ... no such file or directory` inside chezmoi source dir because their paths looked as if they were real chezmoi source files.

The cause was that `detect_filetype` called `target_path:exec()` (sync) during file type detection which auto-logs errors on failure (unavoidable for inexistent files). Replacing `target_path:exec()` with `target_path:async()` resolves this because it does not auto-log errors and leaves that to the 

Also see https://github.com/andre-kotake/nvim-chezmoi/pull/26